### PR TITLE
Support auth and authz by Entra ID on web

### DIFF
--- a/CopilotWorkspace.AppHost/CopilotWorkspace.AppHost.csproj
+++ b/CopilotWorkspace.AppHost/CopilotWorkspace.AppHost.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.1.0" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.1" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.2.1" />
   </ItemGroup>
 
 </Project>

--- a/CopilotWorkspace.ServiceDefaults/CopilotWorkspace.ServiceDefaults.csproj
+++ b/CopilotWorkspace.ServiceDefaults/CopilotWorkspace.ServiceDefaults.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />

--- a/CopilotWorkspace.Web/Components/Pages/Counter.razor
+++ b/CopilotWorkspace.Web/Components/Pages/Counter.razor
@@ -1,5 +1,6 @@
 ﻿@page "/counter"
 @rendermode InteractiveServer
+@attribute [Authorize]
 
 <PageTitle>Counter</PageTitle>
 

--- a/CopilotWorkspace.Web/Components/Pages/Counter.razor
+++ b/CopilotWorkspace.Web/Components/Pages/Counter.razor
@@ -1,4 +1,5 @@
 ﻿@page "/counter"
+@using Microsoft.AspNetCore.Authorization
 @rendermode InteractiveServer
 @attribute [Authorize]
 

--- a/CopilotWorkspace.Web/Components/Pages/Home.razor
+++ b/CopilotWorkspace.Web/Components/Pages/Home.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@attribute [Authorize]
 
 <PageTitle>Home</PageTitle>
 

--- a/CopilotWorkspace.Web/Components/Pages/Home.razor
+++ b/CopilotWorkspace.Web/Components/Pages/Home.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 
 <PageTitle>Home</PageTitle>

--- a/CopilotWorkspace.Web/Components/Pages/License.razor
+++ b/CopilotWorkspace.Web/Components/Pages/License.razor
@@ -1,4 +1,4 @@
-@page "/license"
+﻿@page "/license"
 
 <PageTitle>License</PageTitle>
 
@@ -7,7 +7,7 @@
 <p>@licenseContent</p>
 
 @code {
-    private string licenseContent;
+    private string? licenseContent;
 
     protected override async Task OnInitializedAsync()
     {

--- a/CopilotWorkspace.Web/Components/Pages/Weather.razor
+++ b/CopilotWorkspace.Web/Components/Pages/Weather.razor
@@ -1,6 +1,7 @@
 ﻿@page "/weather"
 @attribute [StreamRendering(true)]
 @attribute [OutputCache(Duration = 5)]
+@attribute [Authorize]
 
 @inject WeatherApiClient WeatherApi
 

--- a/CopilotWorkspace.Web/Components/Pages/Weather.razor
+++ b/CopilotWorkspace.Web/Components/Pages/Weather.razor
@@ -1,4 +1,5 @@
 ﻿@page "/weather"
+@using Microsoft.AspNetCore.Authorization
 @attribute [StreamRendering(true)]
 @attribute [OutputCache(Duration = 5)]
 @attribute [Authorize]

--- a/CopilotWorkspace.Web/CopilotWorkspace.Web.csproj
+++ b/CopilotWorkspace.Web/CopilotWorkspace.Web.csproj
@@ -7,12 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference
-            Include="..\CopilotWorkspace.ServiceDefaults\CopilotWorkspace.ServiceDefaults.csproj" />
+        <ProjectReference Include="..\CopilotWorkspace.ServiceDefaults\CopilotWorkspace.ServiceDefaults.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.1.0" />
+        <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.2.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.10" />
+        <PackageReference Include="Microsoft.Identity.Web" Version="3.2.2" />
+        <PackageReference Include="Microsoft.Identity.Web.UI" Version="3.2.2" />
     </ItemGroup>
 
     <Target Name="CopyLicenseFile" AfterTargets="Build">

--- a/CopilotWorkspace.Web/Program.cs
+++ b/CopilotWorkspace.Web/Program.cs
@@ -1,5 +1,8 @@
 ﻿using CopilotWorkspace.Web;
 using CopilotWorkspace.Web.Components;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.UI;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,6 +21,18 @@ builder.Services.AddHttpClient<WeatherApiClient>(client =>
         client.BaseAddress = new("https+http://apiservice");
     });
 
+// Add Entra ID authentication and authorization services
+builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"));
+
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = options.DefaultPolicy;
+});
+
+builder.Services.AddRazorPages()
+    .AddMicrosoftIdentityUI();
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
@@ -33,6 +48,10 @@ app.UseStaticFiles();
 app.UseAntiforgery();
 
 app.UseOutputCache();
+
+// Add Entra ID authentication and authorization middleware
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/CopilotWorkspace.Web/appsettings.Development.json
+++ b/CopilotWorkspace.Web/appsettings.Development.json
@@ -4,5 +4,12 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "Domain": "yourdomain.onmicrosoft.com",
+    "TenantId": "your-tenant-id",
+    "ClientId": "your-client-id",
+    "CallbackPath": "/signin-oidc"
   }
 }

--- a/CopilotWorkspace.Web/appsettings.json
+++ b/CopilotWorkspace.Web/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "Domain": "yourdomain.onmicrosoft.com",
+    "TenantId": "your-tenant-id",
+    "ClientId": "your-client-id",
+    "CallbackPath": "/signin-oidc"
+  }
 }


### PR DESCRIPTION
Add support for authentication and authorization by Entra ID in the web application.

* **Configuration**:
  - Add Entra ID configuration settings under a new section `AzureAd` in `CopilotWorkspace.Web/appsettings.json`.
  - Add Entra ID configuration settings under a new section `AzureAd` in `CopilotWorkspace.Web/appsettings.Development.json`.

* **Program.cs**:
  - Add Entra ID authentication and authorization services in the `builder.Services` section.
  - Add Entra ID authentication and authorization middleware in the `app` section.

* **Razor Pages**:
  - Add Entra ID authentication and authorization code to protect `Home.razor`.
  - Add Entra ID authentication and authorization code to protect `Counter.razor`.
  - Add Entra ID authentication and authorization code to protect `Weather.razor`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ryotafunaki/tech-survs-copilot-workspace?shareId=c317df6d-5bf8-4d2f-ad46-2e9460f9ac66).