### PR TITLE
Add WebAssembly counter to License page

### DIFF
--- a/CopilotWorkspace.Web/Components/Pages/License.razor
+++ b/CopilotWorkspace.Web/Components/Pages/License.razor
@@ -6,8 +6,12 @@
 
 <p>@licenseContent</p>
 
+<button @onclick="IncrementCount">Click me</button>
+<span>Count: @count</span>
+
 @code {
     private string licenseContent;
+    private int count = 0;
 
     protected override async Task OnInitializedAsync()
     {
@@ -18,5 +22,10 @@
     {
         var licenseFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "LICENSE");
         return await File.ReadAllTextAsync(licenseFilePath);
+    }
+
+    private void IncrementCount()
+    {
+        count++;
     }
 }

--- a/CopilotWorkspace.Web/Components/Pages/License.razor
+++ b/CopilotWorkspace.Web/Components/Pages/License.razor
@@ -1,4 +1,5 @@
-@page "/license"
+﻿@page "/license"
+@rendermode InteractiveServer
 
 <PageTitle>License</PageTitle>
 
@@ -10,7 +11,7 @@
 <span>Count: @count</span>
 
 @code {
-    private string licenseContent;
+    private string licenseContent = null!;
     private int count = 0;
 
     protected override async Task OnInitializedAsync()

--- a/CopilotWorkspace.Web/wwwroot/wasm/counter.js
+++ b/CopilotWorkspace.Web/wwwroot/wasm/counter.js
@@ -1,0 +1,6 @@
+let counterValue = 0;
+
+export function incrementCounter() {
+    counterValue++;
+    return counterValue;
+}


### PR DESCRIPTION
This pull request includes updates to the `License.razor` file to add interactive functionality and a new JavaScript file to manage a counter.

Enhancements to `License.razor` page:

* Added `@rendermode InteractiveServer` to enable interactive server-side rendering.
* Introduced a button and a span to display and increment a count value on the page.
* Initialized `licenseContent` and added a new `count` field.
* Created a new method `IncrementCount` to handle button clicks and increment the count.

New JavaScript functionality:

* Added `counter.js` in `wwwroot/wasm` to manage a counter with an `incrementCounter` function.